### PR TITLE
Fixed getEpisodeTVDB for tv episodes without an tvdb ID

### DIFF
--- a/default.py
+++ b/default.py
@@ -268,9 +268,9 @@ class Monitor(xbmc.Monitor):
         log('result=%s' % result)
         if 'unknown' in result['result']['episodedetails']['uniqueid']:
             episode_id = result['result']['episodedetails']['uniqueid']['unknown']
-        if 'imdb' in result['result']['episodedetails']['uniqueid']:
+        elif 'imdb' in result['result']['episodedetails']['uniqueid']:
             episode_id = result['result']['episodedetails']['uniqueid']['imdb']
-        if 'tvdb' in result['result']['episodedetails']['uniqueid']:
+        elif 'tvdb' in result['result']['episodedetails']['uniqueid']:
             episode_id = result['result']['episodedetails']['uniqueid']['tvdb']
         else:
             return False


### PR DESCRIPTION
Because the code had 3 different if statements, the getEpisodeTVDB method always returned false for episodes without a tvdb unique ID.